### PR TITLE
Bugfix: Use module config_source if it is set.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,7 +6,7 @@ class pureftpd::config {
         force   => true,
         owner   => root,
         group   => root,
-        source  => $source ? {
+        source  => $pureftpd::config_source ? {
             undef      => "puppet:///modules/${module_name}/${pureftpd::params::config_source}",
             default => $pureftpd::config_source,
         },


### PR DESCRIPTION
Hi Steffen

I think there is a bug in config.pp. Even if the caller of the module purefetpd defines config_source, it is never used. The  code would ALWAYS use puppet:///modules/${module_name}/${pureftpd::params::config_source} as config source and never $pureftpd::config_source.

Thanks, Michael
