### PR TITLE
Enabling hasstatus for the Service

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -3,7 +3,7 @@ class pureftpd::service {
         ensure     => running,
         enable     => true,
         hasrestart => true,
-        hasstatus  => false,
+        hasstatus  => true,
         require    => Class['pureftpd::config'],
     }
 }


### PR DESCRIPTION
I'm not sure if if was intentional to leave the hasstatus disabled, but it was causing issues on my Ubuntu install with it disabled. I've verified that it works on my Ubuntu 12 machine when enabled.
