### PR TITLE
Add support for PureDB authentication

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -22,4 +22,11 @@ class pureftpd::config {
         require => Class['pureftpd::install'],
         notify  => Class['pureftpd::service'],
     }
+
+    if ($auth_type == 'puredb') {
+        file { '/etc/pure-ftpd/auth/50pure':
+            ensure => 'link',
+            target => '/etc/pure-ftpd/conf/PureDB',
+        }
+    }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,6 +11,7 @@ class pureftpd::params {
         'postgresql': {
           $real_auth_type = '-postgresql'
         }
+        'puredb':
         default: {
           $real_auth_type = ''
         }


### PR DESCRIPTION
PureDB needs a symlink in `auth/`.
